### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: write
+
 jobs:
   python-code-format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Notipy-DiscordBot/Notipy/security/code-scanning/1](https://github.com/Notipy-DiscordBot/Notipy/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions performed in the workflow:
- `contents: write` is required for committing and pushing changes.
- No other permissions are necessary for the workflow.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `python-code-format` job. Since this workflow has only one job, adding the permissions at the root level is sufficient and simplifies the configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
